### PR TITLE
Update CandidateBaseDto.cs

### DIFF
--- a/src/ApiBureau.Bullhorn.Api/Dtos/CandidateBaseDto.cs
+++ b/src/ApiBureau.Bullhorn.Api/Dtos/CandidateBaseDto.cs
@@ -17,13 +17,12 @@ public class CandidateBaseDto : EntityBaseDto
     public bool IsDeleted { get; set; }
     public string Status { get; set; } = null!;
     public long CustomDate2 { get; set; }
-    public List<string> Source { get; set; }
+    public string Source { get; set; }
     public UserDto Owner { get; set; }
     public AddressDto Address { get; set; }
 
     public CandidateBaseDto()
     {
-        Source = new List<string>();
         Owner = new UserDto();
         Address = new AddressDto();
     }


### PR DESCRIPTION
The field "Source" in "CandidateBaseDto" is a "string" and not a "List/Array" according to the Bullhorn API Documentation: https://bullhorn.github.io/rest-api-docs/entityref.html#candidate.

This change fixed the bug I was having trying to query/search Candidates